### PR TITLE
meta-ar: Add kernel modules and toolchain target task for audio support

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -42,9 +42,11 @@ local_conf_header:
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
     IMAGE_INSTALL:append = "packagegroup-qcom-audio"
+    MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append = "packagegroup-qcom-audio-kernel-modules"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
+    TOOLCHAIN_TARGET_TASK += "kernel-devsrc"
   extra: |
     DISTRO_FEATURES:append = " efi pni-names"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"

--- a/recipes/packagegroups/packagegroup-qcom-audio.bb
+++ b/recipes/packagegroups/packagegroup-qcom-audio.bb
@@ -8,7 +8,32 @@ inherit packagegroup
 
 PROVIDES = "${PACKAGES}"
 
-PACKAGES = "${PN}"
+PACKAGES = "${PN} \
+            ${PN}-kernel-modules \
+"
+
+RRECOMMENDS:${PN}-kernel-modules += " \
+    kernel-module-q6apm-dai \
+    kernel-module-q6apm-lpass-dais \
+    kernel-module-q6core \
+    kernel-module-q6prm-clocks \
+    kernel-module-q6prm \
+    kernel-module-q6routing \
+    kernel-module-snd-q6apm \
+    kernel-module-snd-q6dsp-common \
+    kernel-module-snd-soc-qcom-sdw \
+    kernel-module-snd-soc-sc8280xp \
+    kernel-module-snd-soc-qcm6490 \
+    kernel-module-snd-soc-qcs9100 \
+    kernel-module-snd-soc-lpass-macro-common \
+    kernel-module-snd-soc-lpass-rx-macro \
+    kernel-module-snd-soc-lpass-tx-macro \
+    kernel-module-snd-soc-lpass-va-macro \
+    kernel-module-snd-soc-lpass-wsa-macro \
+    kernel-module-snd-soc-wsa883x \
+    kernel-module-soundwire-qcom \
+    kernel-module-soundwire-bus \
+"
 
 PULSEAUDIO_PKGS = " \
     pulseaudio-server \


### PR DESCRIPTION
 - Append `packagegroup-qcom-audio-kernel-modules` to `MACHINE_ESSENTIAL_EXTRA_RDEPENDS`
 - Add `kernel-devsrc` to `TOOLCHAIN_TARGET_TASK`
 - Include kernel modules audio package.