### PR TITLE
Use Docker GHA cache

### DIFF
--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -15,13 +15,28 @@ runs:
       with:
         fetch-depth: 0
         repository: Audioreach/ar-image
-
-    - name: Build Docker Image
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Pre-Build Docker Image
       shell: bash
-      id: build
       run: |
         echo "::group::$(printf '__________ %-100s' 'build' | tr ' ' _)"
-        docker build -t ar-image:latest --build-arg "USER=$(whoami)" --build-arg "UID=$(id -u)" --build-arg "GID=$(id -g)" -f Dockerfile .
+    - name: Build Docker Image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: false
+        tags: ar-image:latest
+        build-args: |
+          "USER=$(whoami)"
+          "UID=$(id -u)"
+          "GID=$(id -g)"
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - name: Post-Build Docker Image
+      shell: bash
+      run: |
         echo "::endgroup::"
         echo "Docker image ar-image:latest built successfully."
         echo "image_name=ar-image:latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It's much faster and more efficient to cache the layers from the generated Docker image.