### PR TITLE
Update docker_build action to pass build_args properly

### DIFF
--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -4,7 +4,7 @@ description: Build Docker Image Action
 outputs:
   image_name:
     description: Name of the built Docker image
-    value: ${{ steps.build.outputs.image_name }}
+    value: ${{ steps.post-build.outputs.image_name }}
 
 runs:
   using: "composite"
@@ -15,29 +15,41 @@ runs:
       with:
         fetch-depth: 0
         repository: Audioreach/ar-image
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+
     - name: Pre-Build Docker Image
+      id: pre-build
       shell: bash
       run: |
-        echo "::group::$(printf '__________ %-100s' 'build' | tr ' ' _)"
+        uid=$(id -u)
+        gid=$(id -g)
+        user=$(whoami)
+        echo "uid=$uid" >> "$GITHUB_OUTPUT"
+        echo "gid=$gid" >> "$GITHUB_OUTPUT"
+        echo "user=$user" >> "$GITHUB_OUTPUT"
+        echo "Running as user: $user (UID: $uid, GID: $gid)"
+
     - name: Build Docker Image
       id: build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: false
+        load: true
         tags: ar-image:latest
         build-args: |
-          "USER=$(whoami)"
-          "UID=$(id -u)"
-          "GID=$(id -g)"
+          "USER=${{ steps.pre-build.outputs.user }}"
+          "UID=${{ steps.pre-build.outputs.uid }}"
+          "GID=${{ steps.pre-build.outputs.gid }}"
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
     - name: Post-Build Docker Image
+      id: post-build
       shell: bash
       run: |
-        echo "::endgroup::"
         echo "Docker image ar-image:latest built successfully."
         echo "image_name=ar-image:latest" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# Description

This PR aims to fix the build issues with docker image.

### RCA:

The build args were not passed properly to the `docker-build-push` action which was resulting in the docker image build failures.
also the `image_name` output was not set properly. 

Fix for this commit: 08697bf828221bd35e22d3b24451ab3890df7e96