### PR TITLE
meta-ar: Disable VUI Module for PulseAudio

### DIFF
--- a/recipes/audio/pulseaudio/system.pa
+++ b/recipes/audio/pulseaudio/system.pa
@@ -29,7 +29,6 @@
 
 load-module module-dbus-protocol
 load-module module-pal-card
-load-module module-pal-voiceui-card
 #load-module module-remap-sink sink_name=offload0_remap remix=no master=offload0 channels=2 master_channel_map=front-left,front-right channel_map=front-left,front-right
 
 ### Load several protocols


### PR DESCRIPTION
Remove 'module-pal-voiceui-card' from system.pa to disable VoiceUI functionality, as VUI is disabled in audioreach-pulseaudio-plugin configuration.