### PR TITLE
meta-ar: Disable PulseAudio idle timeout to prevent automatic shutdown

### DIFF
--- a/recipes/audio/pulseaudio/pulseaudio.service
+++ b/recipes/audio/pulseaudio/pulseaudio.service
@@ -7,7 +7,7 @@ After=adbd.service
 Type=notify
 User = root
 Group = root
-ExecStart=/usr/bin/pulseaudio -n --file=/etc/pulse/system.pa --daemonize=no -v
+ExecStart=/usr/bin/pulseaudio -n --file=/etc/pulse/system.pa --daemonize=no --exit-idle-time=-1 -v
 Restart=on-failure
 RestartSec=3
 StateDirectory=pulse


### PR DESCRIPTION
Modify the pulseaudio systemd service to include the --exit-idle-time=-1 flag in ExecStart. This ensures the PulseAudio daemon does not exit after 20 seconds of inactivity, which is critical for maintaining persistent audio services in embedded/root-mode environments.