### PR TITLE
CONTRIBUTING.md: Update default branch reference to 'main'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,16 @@ Your help is essential for keeping this project great and for making it better.
 
 ## Branching Strategy
 
-In general, contributors should develop on branches based off of `master` and pull requests should be made against `master`.
+In general, contributors should develop on branches based off of `main` and pull requests should be made against `main`.
 
 ## Submitting a pull request
 
 1. Please read our [code of conduct](CODE-OF-CONDUCT.md) and [license](LICENSE).
 1. Fork and clone the repository.
-1. Create a new branch based on `master`: `git checkout -b <my-branch-name> master`.
+1. Create a new branch based on `main`: `git checkout -b <my-branch-name> main`.
 1. Make your changes, add tests, and make sure the tests still pass.
 1. Commit your changes using the [DCO](http://developercertificate.org/). You can attest to the DCO by commiting with the **-s** or **--signoff** options or manually adding the "Signed-off-by":
-1. Push to your fork and submit a pull request from your branch to `master`.
+1. Push to your fork and submit a pull request from your branch to `main`.
 1. Pat yourself on the back and wait for your pull request to be reviewed.
 
 Here are a few things you can do that will increase the likelihood of your pull request to be accepted:


### PR DESCRIPTION
CONTRIBUTING.md points to a non-existing branch name `master`. Replace outdated references to the 'master' branch with 'main' to ensure alignment with the current default branch and avoid confusion for contributors.