### PR TITLE
README: Update build and flash instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,130 @@
 
 This is a temporary repository for hosting the OpenEmbedded meta-layer for AudioReach on Qualcomm platforms.
 
-Install kas latest version with pip.
+## Quick build
 
-->sudo apt-get remove kas
+Please refer to the [Yocto Project Reference Manual](https://docs.yoctoproject.org/ref-manual/system-requirements.html)
+to set up your Yocto Project build environment.
 
-->pip install kas
+Please follow the instructions below for a KAS-based build. The KAS tool offers
+an easy way to setup bitbake based projects. For more details, visit the
+[KAS documentation](https://kas.readthedocs.io/en/latest/index.html).
 
-In the working directory, clone the following repositories:
+1. Install kas tool
 
-->git clone https://github.com/Audioreach/meta-ar.git
+    ```
+    sudo pip3 install kas
+    ```
 
-In working directory run this command to set up your build environment and start compilation:
+2. Clone meta-ar layer
 
-->kas shell meta-ar/ci/qcs6490-rb3gen2-core-kit.yml
+    ```
+    git clone https://github.com/Audioreach/meta-ar.git -b main
+    ```
 
-for apply kernel patch
+3. Build using the KAS configuration for one of the supported boards
 
-->cd ../meta-qcom
+    ```
+    kas build meta-ar/ci/qcs6490-rb3gen2-core-kit.yml
+    ```
 
-->git fetch git@github.com:qualcomm-linux/meta-qcom.git 78f13cf900b6df8176cbe722576aebbdf9a4d70d && git cherry-pick FETCH_HEAD
+For a manual build without KAS, refer to the [Yocto Project Quick Build](https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html).
 
-->cd ../build
+## Flash
 
-->umask 022
+### Build QDL tool
 
-->bitbake core-image-base
+QDL tool communicates with USB devices of PID:VID `05c6:9008` and uploads a
+flash loader, which is then used for flashing images. Follow the steps below
+to download and compile QDL for your platform:
 
-in above step replace yml file based on machines compilation required:
+1. Clone the QDL repository:
 
-->Lemans: qcs9100-ride-sx.yml
+   ```
+   git clone https://github.com/linux-msm/qdl
+   ```
 
-->Monaco: qcs8300-ride-sx.yml
+2. Read the README and install build dependencies (`libxml2-dev` and
+   `libusb-1.0-0-dev`). On Debian-based distribution run:
 
-->Kodiak: qcs6490-rb3gen2-core-kit.yml
+   ```
+   sudo apt install libxml2-dev libusb-1.0-0-dev
+   ```
 
+3. Build the QDL tool using make:
+
+   ```
+   cd qdl
+   make
+   ```
+
+As QDL tool requires raw USB access, so to able to run it from non-root user
+create an appropriate `udev` rule by following steps described in
+[Update udev rules](https://docs.qualcomm.com/bundle/publicresource/topics/80-70014-254/flash_images_unregistered.html#update-udev-rules)
+
+### Prepare the Board
+
+#### RB3 Gen 2
+
+Location of all DIP switches, USB debug port and buttons (`F_DL` for instance)
+can be found on [RB3 Gen 2 Quick Start Guide](https://docs.qualcomm.com/bundle/publicresource/topics/80-70014-253/ubuntu_host.html).
+
+1. Set up `DIP_SW_0` positions `1` and `2` to `ON`. This enables serial output
+   to the debug port.
+2. To put the device into EDL mode press and hold the `F_DL` button
+   before connecting the power cable.
+
+### Flash images
+
+Make sure that ModemManager is not running, disable it if necessary.
+
+1. Connect the micro USB debug cable to the host. Baud rate should be `115200`.
+   Check in `dmesg` how UART shows up (e.g. `/dev/ttyUSB0`):
+
+   ```
+   $ sudo dmesg | grep tty
+   [217664.921039] usb 3-1.1.4: FTDI Serial Device converter attached to ttyUSB0
+   ```
+
+2. Use your favorite serial comminication program to access the console, such
+   as minicom, picocom, putty etc. Baud rate should be 115200:
+
+   ```
+   picocom -b 115200 /dev/ttyUSB0
+   ```
+
+3. Plug in the USB-C cable from the host.
+
+4. Use the QDL tool (built in the previous section) to flash the images:
+
+   ```
+   cd build/tmp/deploy/images/qcs6490-rb3gen2-core-kit/core-image-base-qcs6490-rb3gen2-core-kit.rootfs.qcomflash
+   qdl --debug prog_firehose_ddr.elf rawprogram*.xml patch*.xml
+   ```
+
+   If you have multiple boards connected the host, provide the serial
+   number of the board to flash through `--serial` param:
+
+   ```
+   qdl --serial=0AA94EFD --debug prog_firehose_ddr.elf rawprogram*.xml patch*.xml
+   ```
+
+   Serial can be obtained using `lsusb -v -d 05c6:9008` command.
+
+5. Ensure that the device is booted in Emergency Download (EDL) mode
+   (please refer to Quick Start Guide for your board). The process of
+   flashing should start automatically:
+
+   ```
+   USB: using out-chunk-size of 1048576
+   HELLO version: 0x2 compatible: 0x1 max_len: 1024 mode: 0
+   READ64 image: 13 offset: 0x0 length: 0x40
+   ```
+
+## Maintainer(s)
+
+* Patrick Lai <plai@qti.qualcomm.com>
+* Aditya Rathi <aditrath@qti.qualcomm.com>
 
 # License
 meta-audioreach is licensed under the MIT License. Check out the [LICENSE](LICENSE) for more details


### PR DESCRIPTION
Replace minimal setup steps with comprehensive guidance for building AudioReach using the KAS tool on Qualcomm platforms.
Add installation instructions, repository cloning steps, build commands and links to official Yocto and KAS documentation.
Add QDL flashing section with installation, usage, and RB3 Gen 2 setup instructions.