### PR TITLE
ci/base.yml: Add meta-openembedded layers to Yocto distribution

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -30,6 +30,13 @@ repos:
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom.git
 
+  meta-openembedded:
+    url: https://github.com/openembedded/meta-openembedded
+    layers:
+      meta-multimedia:
+      meta-oe:
+      meta-python:
+
   meta-ar:
     path: meta-ar
 


### PR DESCRIPTION
This change integrates the meta-openembedded layer into the Yocto distribution configuration. Enabling support for tinyalsa and pipewire recipe.