### PR TITLE
Add AudioReach driver recipe

### DIFF
--- a/recipes-kernel/audioreach-module/audioreach-dlkm_git.bb
+++ b/recipes-kernel/audioreach-module/audioreach-dlkm_git.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Qualcomm AudioReach kernel module"
+DESCRIPTION = "This module is designed for integration with the AudioReach framework, allowing flexible deployment of audio algorithms and efficient hardware utilization."
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0a5a2ad232bafb6974f9a29d1ba0f488"
+
+SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;branch=master"
+SRCREV = "c494af74e420661591a3715f02e4f21f4944a0f2"
+
+PV = "0.0+git"
+
+inherit module
+
+MAKE_TARGETS = "modules"
+
+MODULES_MODULE_SYMVERS_LOCATION = "audioreach-driver"
+
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
audioreach driver recipe introduces the AudioReach kernel module, which enables advanced, efficient, and modular audio processing on Qualcomm platforms.

Initially, a PR was created in the meta-qcom layer. However, based on discussions with the maintainers, it was concluded that the driver is better suited for the meta-ar layer.
Therefore, this PR migrates the same content to meta-ar for better alignment with layer responsibilities and modularity.

https://github.com/qualcomm-linux/meta-qcom/pull/1062
