### PR TITLE
audioreach-dlkm: Add udev rules for audio devices

### DIFF
--- a/recipes-kernel/audioreach-module/audioreach-dlkm/audioreach.rules
+++ b/recipes-kernel/audioreach-module/audioreach-dlkm/audioreach.rules
@@ -1,0 +1,2 @@
+KERNEL=="msm_audio_mem", GROUP="audio", MODE="0660"
+KERNEL=="aud_pasthru_adsp", GROUP="audio", MODE="0660"

--- a/recipes-kernel/audioreach-module/audioreach-dlkm_git.bb
+++ b/recipes-kernel/audioreach-module/audioreach-dlkm_git.bb
@@ -4,7 +4,9 @@ DESCRIPTION = "This module is designed for integration with the AudioReach frame
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0a5a2ad232bafb6974f9a29d1ba0f488"
 
-SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/AudioReach/audioreach-kernel.git;protocol=https;branch=master \
+           file://audioreach.rules \
+    "
 SRCREV = "c494af74e420661591a3715f02e4f21f4944a0f2"
 
 PV = "0.0+git"
@@ -14,6 +16,13 @@ inherit module
 MAKE_TARGETS = "modules"
 
 MODULES_MODULE_SYMVERS_LOCATION = "audioreach-driver"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${UNPACKDIR}/audioreach.rules ${D}${sysconfdir}/udev/rules.d/
+}
+
+FILES:${PN} += "${sysconfdir}/udev/rules.d/audioreach.rules"
 
 COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"


### PR DESCRIPTION
Create audioreach.rules to configure permissions for audio devices.