### PR TITLE
packagegroup-qcom-audio: Add AudioReach pipewire plugin and DLKM

### DIFF
--- a/recipes/packagegroups/packagegroup-qcom-audio.bb
+++ b/recipes/packagegroups/packagegroup-qcom-audio.bb
@@ -18,4 +18,6 @@ RDEPENDS:${PN} = ' \
     audioreach-graphmgr \
     audioreach-graphservices \
     audioreach-pal \
+    audioreach-pipewire-plugin \
+    audioreach-dlkm \
 '


### PR DESCRIPTION
This change adds `audioreach-pipewire-plugin` and `audioreach-dlkm` to the runtime dependencies of the `packagegroup-qcom-audio` package group.