### PR TITLE
pipewire: Add pipewire user to 'kmem' group

### DIFF
--- a/recipes/pipewire/pipewire_%.bbappend
+++ b/recipes/pipewire/pipewire_%.bbappend
@@ -1,0 +1,5 @@
+#Add pipewire user to kmem group
+USERADD_PARAM:${PN} = "--system --home / --no-create-home \
+                       --comment 'PipeWire multimedia daemon' \
+                       --gid pipewire --groups audio,video,kmem \
+                       pipewire"


### PR DESCRIPTION
AudioReach requires access to /dev/dma_heap/system for buffer allocation via the DMA-BUF Heap interface.
To enable this, the pipewire user is now added to the 'kmem' group through USERADD_PARAM.