### PR TITLE
layer.conf: Add multimedia-layer dependency

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,4 +4,6 @@ BBPATH .= ":${LAYERDIR}"
 BBFILE_COLLECTIONS += "meta-ar"
 BBFILE_PRIORITY_meta-ar = "6"
 BBFILE_PATTERN_meta-ar := "^${LAYERDIR}/"
+
+LAYERDEPENDS_meta-ar = "multimedia-layer"
 LAYERSERIES_COMPAT_meta-ar = "whinlatter"


### PR DESCRIPTION
The audioreach-pipewire-plugin recipe depends on pipewire, which is provided by multimedia-layer.