### PR TITLE
audioreach-pal: switch to master branch

### DIFF
--- a/recipes/audioreach-pal/audioreach-pal-headers_git.bb
+++ b/recipes/audioreach-pal/audioreach-pal-headers_git.bb
@@ -6,7 +6,7 @@ LICENSE = "BSD-3-Clause & BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://PalDefs.h;beginline=30;endline=31;md5=e733afaf233fbcbc22769d0a9bda0b3e"
 
 SRCPROJECT = "git://github.com/Audioreach/audioreach-pal.git"
-SRCBRANCH  = "qclinux1.0"
+SRCBRANCH  = "master"
 SRCREV     = "2f6501d770f585aa7dbdfb95606a95af6782806a"
 
 SRC_URI = "${SRCPROJECT};protocol=https;branch=${SRCBRANCH};"

--- a/recipes/audioreach-pal/audioreach-pal_git.bb
+++ b/recipes/audioreach-pal/audioreach-pal_git.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://Pal.cpp;beginline=31;endline=32;md5=e733afaf233fbcbc22769d0a9bda0b3e"
 
 SRCPROJECT = "git://github.com/Audioreach/audioreach-pal.git"
-SRCBRANCH  = "qclinux1.0"
+SRCBRANCH  = "master"
 
 SRCREV = "2f6501d770f585aa7dbdfb95606a95af6782806a"
 PV = "0.0+git"


### PR DESCRIPTION
Change SRCBRANCH from 'qclinux1.0' to 'master' to follow mainline development.